### PR TITLE
refactor: [#31] Refactoring: MessageBuilder 인터페이스 build 메소드에서 파라미터 제거…

### DIFF
--- a/src/main/java/baseball/controller/inputacceptor/GuessInputAcceptor.java
+++ b/src/main/java/baseball/controller/inputacceptor/GuessInputAcceptor.java
@@ -7,7 +7,7 @@ public class GuessInputAcceptor implements InputAcceptor {
     @Override
     public String readLine() {
         GuessInputMessageBuilder guessInputMessageBuilder = new GuessInputMessageBuilder();
-        System.out.print(guessInputMessageBuilder.build(null));
+        System.out.print(guessInputMessageBuilder.build());
         return Console.readLine();
     }
 }

--- a/src/main/java/baseball/view/messagebuilder/GuessInputMessageBuilder.java
+++ b/src/main/java/baseball/view/messagebuilder/GuessInputMessageBuilder.java
@@ -4,7 +4,7 @@ import baseball.model.scorebuilder.Score;
 
 public class GuessInputMessageBuilder implements MessageBuilder {
     @Override
-    public String build(Score score) {
+    public String build() {
         return "숫자를 입력해주세요 : ";
     }
 }

--- a/src/main/java/baseball/view/messagebuilder/GuessResultMessageBuilder.java
+++ b/src/main/java/baseball/view/messagebuilder/GuessResultMessageBuilder.java
@@ -2,8 +2,7 @@ package baseball.view.messagebuilder;
 
 import baseball.model.scorebuilder.Score;
 
-public class GuessResultMessageBuilder implements MessageBuilder {
-    @Override
+public class GuessResultMessageBuilder {
     public String build(Score score) {
         StringBuilder scoreStringBuilder = new StringBuilder();
         if (score.getStrike() == 0 && score.getBall() == 0) {

--- a/src/main/java/baseball/view/messagebuilder/MessageBuilder.java
+++ b/src/main/java/baseball/view/messagebuilder/MessageBuilder.java
@@ -3,5 +3,5 @@ package baseball.view.messagebuilder;
 import baseball.model.scorebuilder.Score;
 
 public interface MessageBuilder {
-    public String build(Score score);
+    public String build();
 }


### PR DESCRIPTION
…, GuessResultMessageBuilder 클래스는 더 이상 인터페이스 사용 안 함

처음에 의도했던 것과 구현 결과가 달라서 약간의 수정을 한다

문제점:

GuessResultMessageBuilder 클래스에서는 build 메소드의 파라미터로 Score 타입을 받지만 나머지 XXXMessageBuilder 클래스에서는 build 메소드의 파라미터로 아무것도 받지 않는다

수정 방향성:

GuessResultMessageBuilder 클래스는 MessageBuilder 인터페이스를 구현하지 않고 나머지 XXXMessageBuilder 클래스는 MessageBuilder 인터페이스를 구현한다