### PR TITLE
chore: 상황에 맞는 View 컴포넌트 사용하는 부분을 InputAcceptor 안으로 옮기기

### DIFF
--- a/src/main/java/baseball/NumberBaseball.java
+++ b/src/main/java/baseball/NumberBaseball.java
@@ -7,8 +7,6 @@ import baseball.model.inputvalidator.GameRestartInputValidator;
 import baseball.model.inputvalidator.GuessInputValidator;
 import baseball.model.scorebuilder.Score;
 import baseball.model.scorebuilder.ScoreBuilder;
-import baseball.view.messagebuilder.GameFinishedMessageBuilder;
-import baseball.view.messagebuilder.GameRestartInputMessageBuilder;
 import baseball.view.messagebuilder.GuessResultMessageBuilder;
 
 import java.util.Objects;
@@ -57,10 +55,6 @@ public class NumberBaseball {
     }
 
     public String readUserRestartOrExit() {
-        GameFinishedMessageBuilder gameFinishedMessageBuilder = new GameFinishedMessageBuilder();
-        System.out.println(gameFinishedMessageBuilder.build());
-        GameRestartInputMessageBuilder gameRestartInputMessageBuilder = new GameRestartInputMessageBuilder();
-        System.out.println(gameRestartInputMessageBuilder.build());
         GameRestartInputAcceptor gameRestartInputAcceptor = new GameRestartInputAcceptor();
         return gameRestartInputAcceptor.readLine();
     }

--- a/src/main/java/baseball/controller/inputacceptor/GameRestartInputAcceptor.java
+++ b/src/main/java/baseball/controller/inputacceptor/GameRestartInputAcceptor.java
@@ -1,10 +1,16 @@
 package baseball.controller.inputacceptor;
 
+import baseball.view.messagebuilder.GameFinishedMessageBuilder;
+import baseball.view.messagebuilder.GameRestartInputMessageBuilder;
 import camp.nextstep.edu.missionutils.Console;
 
 public class GameRestartInputAcceptor implements InputAcceptor {
     @Override
     public String readLine() {
+        GameFinishedMessageBuilder gameFinishedMessageBuilder = new GameFinishedMessageBuilder();
+        System.out.println(gameFinishedMessageBuilder.build());
+        GameRestartInputMessageBuilder gameRestartInputMessageBuilder = new GameRestartInputMessageBuilder();
+        System.out.println(gameRestartInputMessageBuilder.build());
         return Console.readLine();
     }
 }


### PR DESCRIPTION
수정 전:
상황에 맞는 메시지 빌더(GameFinishedMessageBuilder, GameRestartInputMessageBuilder)와 상황에 맞는 사용자 입력 수신자(GameRestartInputAcceptor)가 서로 분리되어 있었다

수정 후:
관련 있는 메시지 빌더와 사용자 입력 수신자를 서로 연관지어서 생각하기 편하도록
함께 사용하도록 수정