### PR TITLE
refactor: [#48] 상수를 별도의 final static 변수로 만들기

### DIFF
--- a/src/main/java/baseball/constant/NumberBaseballConstant.java
+++ b/src/main/java/baseball/constant/NumberBaseballConstant.java
@@ -1,0 +1,11 @@
+package baseball.constant;
+
+public class NumberBaseballConstant {
+    public static final Integer LENGTH_OF_TARGET_NUMBER = 3;
+
+    public static final Integer MINIMUM_OF_EACH_DIGIT = 1;
+    public static final Integer MAXIMUM_OF_EACH_DIGIT = 9;
+
+    public static final Integer GAME_RESTART = 1;
+    public static final Integer PROGRAM_EXIT = 2;
+}

--- a/src/main/java/baseball/controller/NumberBaseballController.java
+++ b/src/main/java/baseball/controller/NumberBaseballController.java
@@ -1,5 +1,6 @@
 package baseball.controller;
 
+import baseball.constant.NumberBaseballConstant;
 import baseball.controller.displayingmessage.DisplayingMessage;
 import baseball.controller.inputacceptor.GameRestartInputAcceptor;
 import baseball.controller.inputacceptor.GuessInputAcceptor;
@@ -9,8 +10,6 @@ import baseball.model.inputvalidator.GuessInputValidator;
 import baseball.model.scorebuilder.Score;
 import baseball.model.scorebuilder.ScoreBuilder;
 import baseball.view.GuessResultMessageBuilder;
-
-import java.util.logging.Logger;
 
 public class NumberBaseballController {
     private Boolean programRunning;
@@ -75,7 +74,7 @@ public class NumberBaseballController {
     }
 
     public Boolean getGamePlayingState(Score guessScore) {
-        return guessScore.getStrike() != 3;
+        return !guessScore.getStrike().equals(NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER);
     }
 
     public String readUserRestartOrExit() {
@@ -91,6 +90,6 @@ public class NumberBaseballController {
     }
 
     public Boolean getProgramRunningState(String restartOrExit) {
-        return restartOrExit.equals("1");
+        return restartOrExit.equals(NumberBaseballConstant.GAME_RESTART.toString());
     }
 }

--- a/src/main/java/baseball/model/RandomNumberGenerator.java
+++ b/src/main/java/baseball/model/RandomNumberGenerator.java
@@ -1,5 +1,6 @@
 package baseball.model;
 
+import baseball.constant.NumberBaseballConstant;
 import camp.nextstep.edu.missionutils.Randoms;
 
 import java.util.HashSet;
@@ -10,12 +11,12 @@ public class RandomNumberGenerator {
     private final StringBuilder randomNumberStringBuilder;
 
     public RandomNumberGenerator() {
-        this.numbers = new HashSet<Integer>();
+        this.numbers = new HashSet<>();
         this.randomNumberStringBuilder = new StringBuilder();
     }
 
     public String generate() {
-        while (randomNumberStringBuilder.length() < 3) {
+        while (randomNumberStringBuilder.length() < NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER) {
             whileLoop();
         }
         return randomNumberStringBuilder.toString();

--- a/src/main/java/baseball/model/inputvalidator/GameRestartInputValidator.java
+++ b/src/main/java/baseball/model/inputvalidator/GameRestartInputValidator.java
@@ -1,10 +1,12 @@
 package baseball.model.inputvalidator;
 
-import java.util.logging.Logger;
+import baseball.constant.NumberBaseballConstant;
 
 public class GameRestartInputValidator implements InputValidator {
     @Override
     public Boolean validate(String input) {
-        return input != null && (input.equals("1") || input.equals("2"));
+        return input != null && (
+                input.equals(NumberBaseballConstant.GAME_RESTART.toString()) ||
+                        input.equals(NumberBaseballConstant.PROGRAM_EXIT.toString()));
     }
 }

--- a/src/main/java/baseball/model/inputvalidator/GuessInputValidator.java
+++ b/src/main/java/baseball/model/inputvalidator/GuessInputValidator.java
@@ -1,5 +1,7 @@
 package baseball.model.inputvalidator;
 
+import baseball.constant.NumberBaseballConstant;
+
 public class GuessInputValidator implements InputValidator {
     private Boolean validateResult;
 
@@ -9,17 +11,20 @@ public class GuessInputValidator implements InputValidator {
 
     @Override
     public Boolean validate(String guess) {
-        if (guess == null || guess.length() != 3) {
+        if (guess == null || guess.length() != NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER) {
             return false;
         }
-        for (int i = 0; i < 3; ++i) {
+        for (int i = 0; i < NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER; ++i) {
             validateDigitInRangeOneToNine(guess.charAt(i));
         }
         return validateResult;
     }
 
     private void validateDigitInRangeOneToNine(Character c) {
-        if (c < '1' || '9' < c) {
+        if (
+                c < (char) (NumberBaseballConstant.MINIMUM_OF_EACH_DIGIT + '0') ||
+                        (char) (NumberBaseballConstant.MAXIMUM_OF_EACH_DIGIT + '0') < c
+        ) {
             validateResult = false;
         }
     }

--- a/src/main/java/baseball/model/scorebuilder/ScoreBuilder.java
+++ b/src/main/java/baseball/model/scorebuilder/ScoreBuilder.java
@@ -1,5 +1,7 @@
 package baseball.model.scorebuilder;
 
+import baseball.constant.NumberBaseballConstant;
+
 public class ScoreBuilder {
     private final Score score;
 
@@ -8,7 +10,7 @@ public class ScoreBuilder {
     }
 
     public Score build(String target, String guess) {
-        for (int i = 0; i < 3; ++i) {
+        for (int i = 0; i < NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER; ++i) {
             Boolean sameCharacter = isSameCharacter(target.charAt(i), guess.charAt(i));
             Boolean samePosition = isSamePosition(target, guess.charAt(i));
             addScoreForCurrentDigit(sameCharacter, samePosition);

--- a/src/main/java/baseball/view/messagebuilder/GameFinishedMessageBuilder.java
+++ b/src/main/java/baseball/view/messagebuilder/GameFinishedMessageBuilder.java
@@ -1,8 +1,10 @@
 package baseball.view.messagebuilder;
 
+import baseball.constant.NumberBaseballConstant;
+
 public class GameFinishedMessageBuilder implements MessageBuilder {
     @Override
     public String build() {
-        return "3개의 숫자를 모두 맞히셨습니다! 게임 종료";
+        return NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER + " 개의 숫자를 모두 맞히셨습니다! 게임 종료";
     }
 }

--- a/src/main/java/baseball/view/messagebuilder/GameRestartInputMessageBuilder.java
+++ b/src/main/java/baseball/view/messagebuilder/GameRestartInputMessageBuilder.java
@@ -1,8 +1,11 @@
 package baseball.view.messagebuilder;
 
+import baseball.constant.NumberBaseballConstant;
+
 public class GameRestartInputMessageBuilder implements MessageBuilder {
     @Override
     public String build() {
-        return "게임을 새로 시작하려면 1, 종료하려면 2를 입력하세요";
+        return "게임을 새로 시작하려면 " + NumberBaseballConstant.GAME_RESTART +
+                ", 종료하려면 " + NumberBaseballConstant.PROGRAM_EXIT + " 를 입력하세요";
     }
 }

--- a/src/test/java/baseball/model/RandomNumberGeneratorTest.java
+++ b/src/test/java/baseball/model/RandomNumberGeneratorTest.java
@@ -1,5 +1,6 @@
 package baseball.model;
 
+import baseball.constant.NumberBaseballConstant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
@@ -32,8 +33,11 @@ public class RandomNumberGeneratorTest {
     }
 
     private Boolean validateEachDigitInRangeOneToNine(String str) {
-        for (int i = 0; i < 3; ++i) {
-            if (str.charAt(i) < '1' && '9' < str.charAt(i)) {
+        for (int i = 0; i < NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER; ++i) {
+            if (
+                    str.charAt(i) < (char) (NumberBaseballConstant.MINIMUM_OF_EACH_DIGIT + '0') &&
+                            (char) (NumberBaseballConstant.MAXIMUM_OF_EACH_DIGIT + '0') < str.charAt(i)
+            ) {
                 return false;
             }
         }
@@ -48,8 +52,8 @@ public class RandomNumberGeneratorTest {
     }
 
     private Boolean validateNoDuplicateDigitInString(String str) {
-        Set<Character> digitsInString = new HashSet<Character>();
-        for (int i = 0; i < 3; ++i) {
+        Set<Character> digitsInString = new HashSet<>();
+        for (int i = 0; i < NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER; ++i) {
             digitsInString.add(str.charAt(i));
         }
         return digitsInString.size() == 3;


### PR DESCRIPTION
수정 이유:
코드 안에서 상수를 직접 사용하게 되면 나중에 요구조건이 바뀌었을 떄
해당 상수를 사용한 곳을 모두 찾아서 바꿔야 하는 어려움이 있다.
상수를 별도의 final static 변수로 선언해두면 나중에 한 군데만 수정해도
전체 로직을 간단하게 수정할 수 있게 된다.

수정 후:
LENGTH_OF_TARGET_NUMBER: 맞춰야 하는 숫자의 길이
MINIMUM_OF_EACH_DIGIT: 각 자리에 들어갈 수 있는 숫자 최소값
MAXIMUM_OF_EACH_DIGIT: 각 자리에 들어갈 수 있는 숫자 최대값
GAME_RESTART: 새로운 게임을 시작할때는 1 입력
PROGRAM_EXIT: 프로그램을 종료하고 나가려면 2 입력

관련 일감 링크
[상수를 별도의 final static 변수로 만들기](https://github.com/OptimistLabyrinth/java-baseball-precourse/issues/48)