### PR TITLE
chore: 메소드명 변경

### DIFF
--- a/src/main/java/baseball/model/RandomNumberGenerator.java
+++ b/src/main/java/baseball/model/RandomNumberGenerator.java
@@ -17,12 +17,12 @@ public class RandomNumberGenerator {
 
     public String generate() {
         while (randomNumberStringBuilder.length() < NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER) {
-            whileLoop();
+            generateOneDigit();
         }
         return randomNumberStringBuilder.toString();
     }
 
-    private void whileLoop() {
+    private void generateOneDigit() {
         Integer randomNumber = Randoms.pickNumberInRange(1, 9);
         if (!numbers.contains(randomNumber)) {
             randomNumberStringBuilder.append(randomNumber);


### PR DESCRIPTION
수정 전:
함수가 하는 일이 무엇인지 파악하기 어려운 whileLoop 과 같은 메소드명을 사용하고 있었다

수정 후:
해당 함수는 1 ~ 9 범위의 숫자 중 하나를 무작위로 선택하는 함수이므로
이런 의미를 조금 더 명확하게 파악할 수 있도록 메소드명을 generateOneDigit 으로 변경한다