### PR TITLE
feature: [#56] ScoreBuilder 클래스 수정

### DIFF
--- a/src/main/java/baseball/model/scorebuilder/ScoreBuilder.java
+++ b/src/main/java/baseball/model/scorebuilder/ScoreBuilder.java
@@ -11,27 +11,17 @@ public class ScoreBuilder {
 
     public Score build(String target, String guess) {
         for (int i = 0; i < NumberBaseballConstant.LENGTH_OF_TARGET_NUMBER; ++i) {
-            Boolean sameCharacter = isSameCharacter(target.charAt(i), guess.charAt(i));
-            Boolean samePosition = isSamePosition(target, guess.charAt(i));
-            addScoreForCurrentDigit(sameCharacter, samePosition);
+            incrementStrikeOrBall(target, i, guess.charAt(i));
         }
         return score;
     }
 
-    private Boolean isSameCharacter(Character targetCharacter, Character guessCharacter) {
-        return targetCharacter.equals(guessCharacter);
-    }
-
-    private Boolean isSamePosition(String target, Character guessCharacter) {
-        return target.indexOf(guessCharacter) != -1;
-    }
-
-    private void addScoreForCurrentDigit(Boolean sameCharacter, Boolean samePosition) {
-        if (sameCharacter && samePosition) {
+    private void incrementStrikeOrBall(String target, int i, Character guessCharacter) {
+        if (((Character) target.charAt(i)).equals(guessCharacter)) {
             score.incrementStrike();
             return;
         }
-        if (samePosition) {
+        if (target.indexOf(guessCharacter) != -1) {
             score.incrementBall();
         }
     }


### PR DESCRIPTION
메소드 이름에 맞게 내부구현 수정한다
isSameCharacter 메소드가 이름만 읽으면 같은 숫자가 있는지 확인하는 것 같지만 실제로는 strike 조건에 맞는지, 즉 같은 숫자가 같은 위치에 있는지 확인하고 있다
메소드가 이름에 맞는 구현으로 수정한다

수정 전:
isSameCharacter, isSamePosition, addScoreForCurrentDigit 메소드가 나뉘어 있었다

수정 후:
incrementStrikeOrBall 메소드에서 입력값 판단 후
스트라이크 또는 볼 값을 +1 한다

관련 일감 링크
[ScoreBuilder 클래스 수정](https://github.com/OptimistLabyrinth/java-baseball-precourse/issues/56)