### PR TITLE
refactor: [#57] GuessResultMessageBuilder 클래스 build 메소드 제약조건에 맞춰서 수정

### DIFF
--- a/src/main/java/baseball/view/GuessResultMessageBuilder.java
+++ b/src/main/java/baseball/view/GuessResultMessageBuilder.java
@@ -8,12 +8,20 @@ public class GuessResultMessageBuilder {
         if (score.getStrike() == 0 && score.getBall() == 0) {
             return "낫싱";
         }
+        appendStringBallIfBallValuePositive(score, scoreStringBuilder);
+        appendStringStrikeIfStrikeValuePositive(score, scoreStringBuilder);
+        return scoreStringBuilder.toString();
+    }
+
+    private void appendStringBallIfBallValuePositive(Score score, StringBuilder scoreStringBuilder) {
         if (0 < score.getBall()) {
             scoreStringBuilder.append(score.getBall()).append("볼 ");
         }
+    }
+
+    private void appendStringStrikeIfStrikeValuePositive(Score score, StringBuilder scoreStringBuilder) {
         if (0 < score.getStrike()) {
             scoreStringBuilder.append(score.getStrike()).append("스트라이크");
         }
-        return scoreStringBuilder.toString();
     }
 }


### PR DESCRIPTION
모든 메소드 길이를 10 라인 이내로 제한하는 제약 조건에 맞춰서
build 메소드를 분리한다.

관련 일감 링크
[GuessResultMessageBuilder 클래스 build 메소드 제약조건에 맞춰서 수정](https://github.com/OptimistLabyrinth/java-baseball-precourse/issues/57)