### PR TITLE
docs: 구현 내용에 맞춰서 docs/README.md 수정

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -123,7 +123,7 @@ sequenceDiagram
     - GuessInputMessageBuilder
     - GuessResultMessageBuilder
     - GameFinishedMessageBuilder
-    - GameRestartInputMessageBuilder
+- GameRestartInputMessageBuilder (메소드 build 의 파라미터가 위의 세 개의 구체 클래스와 달라서 별도로 분리)
 
 ## Model 영역에서 사용할 클래스/인터페이스
 


### PR DESCRIPTION
GuessResultMessageBuilder 클래스에 구현한 build 메소드의 파라미터가 
다른 세 개의 MessageBuilder 인터페이스에 대한 구현체와 파라미터가 달라서 클래스를 별도로 위치에 놓았다.
이 부분에 맞추서 문서를 수정한다.