### PR TITLE
refactor: [#63] ParameterizedTest, RepeatedTest 에서 테스트 케이스 세부 정보 보여주기

### DIFF
--- a/src/test/java/baseball/model/scorebuilder/ScoreBuilderTest.java
+++ b/src/test/java/baseball/model/scorebuilder/ScoreBuilderTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ScoreBuilderTest {
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}, {1}, 점수는 {2}-{3}")
     @DisplayName("세 자리 숫자 입력에 대해서 올바른 strike, ball 을 반환해야 한다")
     @CsvSource(value = {"123:123:3:0", "123:124:2:0", "123:135:1:1", "123:891:0:1", "123:312:0:3"}, delimiter = ':')
     public void shouldGetCorrectStrikeAdnBall(

--- a/src/test/java/baseball/view/GuessResultMessageBuilderTest.java
+++ b/src/test/java/baseball/view/GuessResultMessageBuilderTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GuessResultMessageBuilderTest {
-    @ParameterizedTest
+    @ParameterizedTest(name = "점수가 ball: 0 이면 메시지에 스트라이크 값 {0} 을 포함하고 있어야 한다.")
     @DisplayName("점수가 ball: 0 이면 메시지에 스트라이크 값을 포함하고 있어야 한다.")
     @ValueSource(ints = {1, 2, 3})
     public void shouldContainStrikeValueOnlyWhenBallIsZero(Integer strike) {
@@ -31,7 +31,7 @@ public class GuessResultMessageBuilderTest {
         assertThat(message).doesNotContain("볼");
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "점수가 strike: 0 이면 메시지에 볼 값 {0} 을 포함하고 있어야 한다.")
     @DisplayName("점수가 strike: 0 이면 메시지에 볼 값을 포함하고 있어야 한다.")
     @ValueSource(ints = {1, 2, 3})
     public void shouldContainBallValueWhenStrikeIsZero(Integer ball) {
@@ -53,7 +53,7 @@ public class GuessResultMessageBuilderTest {
         assertThat(message).doesNotContain("스트라이크");
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "점수가 strike != 0, ball != 0 이면 스트라이크 값 {0}, 볼 값 {1} 을 모두 포함하고 있어야 한다.")
     @DisplayName("점수가 strike != 0, ball != 0 이면 스트라이크 값, 볼 값을 모두 포함하고 있어야 한다.")
     @CsvSource(value = {"1:1", "1:2", "2:1"}, delimiter = ':')
     public void shouldContainBothStrikeValueAndBallValue(Integer strike, Integer ball) {


### PR DESCRIPTION
ParameterizedTest, RepeatedTest 어노테이션에서
name 필드를 사용하면 테스트 실행 결과에서 세부 정보를 드러낼 수 있다

관련 일감 링크
[ParameterizedTest, RepeatedTest 에서 테스트 케이스 세부 정보 보여주기](https://github.com/OptimistLabyrinth/java-baseball-precourse/issues/63)